### PR TITLE
docs: 修复overview-of-ethereum.md以太坊生态分层架构章节结构

### DIFF
--- a/docs/zh/part1/overview-of-ethereum.md
+++ b/docs/zh/part1/overview-of-ethereum.md
@@ -199,6 +199,7 @@ The Merge 只是起点，以太坊的“进化”还在继续！接下来的升�
 ## **四、以太坊生态概览：L1、L2、Sidechains 等**
 
 以太坊的生态系统由多层架构组成，包括 ==**L1（主网）、L2（二层扩展解决方案）、侧链（Sidechains）**== 等，共同支持高吞吐量和低费用的交易处理。
+
 ::: steps
 
 1. **Layer 1（L1）**
@@ -210,13 +211,14 @@ The Merge 只是起点，以太坊的“进化”还在继续！接下来的升�
      - **Optimistic Rollup**：假设交易合法，仅在争议时验证。
      - **ZK Rollup**：通过零知识证明验证交易，无需链上争议。
 3. **侧链（Sidechains）**：独立运行的链，通过桥接与主网交互。
-4. **以太坊生态分层架构**
 
 :::
 
-以太坊生态可以分为以下几个层次：
+### **以太坊生态分层架构**
 
-### 1. **应用层（Application Layer）**
+从软件栈的功能层次来看，以太坊生态可以分为以下几个层次：
+
+#### 1. **应用层（Application Layer）**
 
 用户直接交互的应用和界面：
 
@@ -225,7 +227,7 @@ The Merge 只是起点，以太坊的“进化”还在继续！接下来的升�
 - **钱包应用**：MetaMask、Coinbase Wallet、Rainbow
 - **DAO 工具**：Snapshot、Aragon、Colony
 
-### 2. **协议层（Protocol Layer）**
+#### 2. **协议层（Protocol Layer）**
 
 以太坊的核心基础设施：
 
@@ -233,7 +235,7 @@ The Merge 只是起点，以太坊的“进化”还在继续！接下来的升�
 - **执行层客户端**：Geth、Nethermind、Erigon、Besu
 - **核心协议**：EVM、状态管理、Gas 机制
 
-### 3. **扩展层（Scaling Layer）**
+#### 3. **扩展层（Scaling Layer）**
 
 提升性能和降低成本的解决方案：
 


### PR DESCRIPTION
## 🎯 改动概述

修复overview-of-ethereum.md第四章"以太坊生态概览"中的结构层级问题，将"以太坊生态分层架构"从 steps 列表中移出，作为独立小标题。

## 📝 详细说明

- 将"以太坊生态分层架构"从 steps 列表的第 4 项移出，改为独立的 h3 小标题
- 调整应用层/协议层/扩展层的标题层级（h3 → h4），作为"以太坊生态分层架构"的子内容
- 添加过渡句"从软件栈的功能层次来看"，区分 L1/L2/侧链与生态分层两种不同的分类视角

纯文本改动，无 UI 改动

## 💭 其他说明

原文中“以太坊生态分层架构”与“L1/L2/侧链”被放在同一层级，容易让读者产生误解。实际上两者是不同的分类视角。此次改动通过调整标题层级使这一区分更加清晰。